### PR TITLE
Fix for PHP/PHPUnit Error

### DIFF
--- a/lib/autoload/sfAutoloadAgain.class.php
+++ b/lib/autoload/sfAutoloadAgain.class.php
@@ -69,7 +69,7 @@ class sfAutoloadAgain
     {
       foreach ($autoloads as $position => $autoload)
       {
-        if ($this === $autoload[0])
+        if (is_array($autoload) && $this === $autoload[0])
         {
           break;
         }


### PR DESCRIPTION
Fix for the "Cannot use object of type Closure as array" error.
